### PR TITLE
Flag package supporting watchOS 6+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Pigeon",
-    platforms: [.iOS(.v13), .macOS(.v10_15)],
+	platforms: [.iOS(.v13), .macOS(.v10_15), .watchOS(.v6)],
     products: [
         .library(
             name: "Pigeon",


### PR DESCRIPTION
I'm currently developing an app using Pigeon. I had to copy the sources of Pigeon into my project in order to use Pigeon, because it's not marked to support watchOS. So far everything works just fine with watchOS, so I think it's safe to flag the package as supporting watchOS 6+ (that's the minimum supported version according to Xcode).